### PR TITLE
Add service to force update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ Add the `Bring Todo List` integration from the HA Integrations page, and enter y
 <br>If you are unsure as to what to put here, you can test at this public URL: https://web.getbring.com/locale/articles.<<LOCALE_STRING_GOES_HERE>.json
 <br>Example: Italian: https://web.getbring.com/locale/articles.it-IT.json -- the locale value should be it-IT
 
+
+## Force Sync
+A service exists to force a sync between HA, called `bring.force_bring_sync`
+It requires a todo entity, but will sync ALL todo entities with Bring lists.
+
+```
+service: bring.force_bring_sync
+data: {}
+target:
+  entity_id: todo.bring_todo_home
+```

--- a/custom_components/bring/services.yaml
+++ b/custom_components/bring/services.yaml
@@ -1,4 +1,4 @@
-update:
+force_bring_sync:
   name: Update List Items
   description: Force a connection to the API to refresh the item lists
   target:

--- a/custom_components/bring/services.yaml
+++ b/custom_components/bring/services.yaml
@@ -1,0 +1,7 @@
+update:
+  name: Update List Items
+  description: Force a connection to the API to refresh the item lists
+  target:
+    entity:
+      integration: bring
+      domain: todo

--- a/custom_components/bring/todo.py
+++ b/custom_components/bring/todo.py
@@ -26,6 +26,9 @@ async def async_setup_entry(
 
     async_add_entities(entities, True)
 
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service("update", {}, "_update")
+
 class BringTodoList(CoordinatorEntity, TodoListEntity):
     def __init__(self, coordinator, list_uuid, list_name):
         super().__init__(coordinator)
@@ -171,6 +174,8 @@ class BringTodoList(CoordinatorEntity, TodoListEntity):
         await bring_item.update_status()
         await self.coordinator.async_request_refresh()
 
+    async def _update(self):
+        await self.coordinator.async_request_refresh()
 
 
 class BringTodoItem(TodoItem):

--- a/custom_components/bring/todo.py
+++ b/custom_components/bring/todo.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 
 from homeassistant.components.todo import TodoListEntity, TodoItem, TodoItemStatus, TodoListEntityFeature
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 from homeassistant.util import slugify
@@ -27,7 +28,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
     platform = entity_platform.async_get_current_platform()
-    platform.async_register_entity_service("update", {}, "_update")
+    platform.async_register_entity_service("force_bring_sync", {}, "_force_sync")
 
 class BringTodoList(CoordinatorEntity, TodoListEntity):
     def __init__(self, coordinator, list_uuid, list_name):
@@ -213,7 +214,8 @@ class BringTodoList(CoordinatorEntity, TodoListEntity):
         if update_data:
             await self.coordinator.async_request_refresh()
 
-    async def _update(self):
+    async def _force_sync(self):
+        _LOGGER.debug("Forcing update due to service call")
         await self.coordinator.async_request_refresh()
 
 


### PR DESCRIPTION
This introduces a new service, `bring.force_bring_sync` which forces HA to sync with Bring!.

It requires a todo entity, but will sync all lists as they all share the same coordinator.

```
service: bring.force_bring_sync
data: {}
target:
  entity_id: todo.bring_todo_home
```